### PR TITLE
修改 README 與『檔案導覽與指令面板』中『指令面板（Command Palette）』一節等

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sublime Text 手冊網址：[http://docs.sublimetext.tw/](http://docs.sublimetex
 
 ## 發現錯誤要怎麼幫忙修改？
 
-1. 點一下又上角的按鈕，Fork it！
+1. 點一下右上角的按鈕，Fork it！
 2. 建立一個你自己的 feature branch，例如：`git checkout -b typo-hotfix`
 3. 提交你所做的變更：`git commit -am "鼎立相助 -> 鼎力相助"`
 4. push 到你 GitHub 上的 repo：`git push origin typo-hotfix`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Sublime Text 手冊網址：[http://docs.sublimetext.tw/](http://docs.sublimetex
 
 ## 本地建置
 
-    $ git clone https://github.com/chinghanho/sublimetext-docs.git
-    $ cd sublimetext-docs
-    $ bundle install
-    $ middleman server
+```bash
+$ git clone https://github.com/chinghanho/sublimetext-docs.git
+$ cd sublimetext-docs
+$ bundle install
+$ middleman server
+```
 
 打開瀏覽器訪問 [127.0.0.1:4567](http://127.0.0.1:4567)，That's all。
 

--- a/source/basic-concepts/index.markdown
+++ b/source/basic-concepts/index.markdown
@@ -36,7 +36,7 @@ _Packages/Default_ 是存放所有 Sublime Text 2 預設的程式、巨集、偏
 
 通常有些未封裝的 package，或是自製的語法、巨集或外掛，那麼 _Packages/User_ 是放置這些檔案的最佳地點。
 
-當 Sublime Text 2 進行軟體更新時，不會去更改 _User_ 這個資料夾的檔案，因此你的偏好設定、快捷鍵設定等等，都應該要放在這個地方，而不是去修改 Default 目錄下的檔案，這個部分會在[客製化](/customization)進一步說明。
+當進行 Sublime Text 程序更新時，不會修改 _User_ 中的內容，因此你的偏好設定、快捷鍵設定等，都應放在這裏，而不是去修改 Default 目錄下的檔案，這部分會在[客製化](/customization)進一步說明。
 
 ## <span id="python-console-and-python-api">Python 控制台與 Python API</span>
 

--- a/source/basic-concepts/index.markdown
+++ b/source/basic-concepts/index.markdown
@@ -22,7 +22,7 @@ _Packages_ 目錄就放在 _Data_ 目錄下。
 
 _Packages_ 目錄非常重要，所有程式語言、標記語言的語法上色檔案，以及各種客製化的外掛資源，全部都是放在這個目錄底下。Sublime Text 2 的 package 意義上就像 Firefox 的 add-on、Google Chrome 的 extension，加強原本沒有的功能，可由開發者透過 Sublime Text 2 的 API 用 Python 自行開發，請見 [Python 控制台與 Python API](#python-console-and-python-api)。
 
-你可以直接從 Sublime Text 2 的選單：_Preferences_ >> _Browse Packages_ 開啟系統中 _Packages_ 這個目錄的位置，也可以用[指令面板（Command Palette）](/file-management-and-command-palette#command-palette)呼叫，雖然你目前可能還不知道這是什麼，不過很快就會介紹到。
+你可以直接從 Sublime Text 2 的選單：_Preferences_ >> _Browse Packages_ 開啟系統中 _Packages_ 這個目錄的位置，也可以用[指令面板（Command Palette）](/file-management-and-command-palette/#command-palette)呼叫，雖然你目前可能還不知道這是什麼，不過很快就會介紹到。
 
 當你瀏覽這個目錄的時候會看到很多程式語言的名字，裡面通常放的都是支援這些語言的語法上色規則，或是巨集、自動完成的程式碼片段等等，可是其中有兩個看起來很不一樣，那就是 _Default_、_User_ 這兩個目錄。
 

--- a/source/file-management-and-command-palette/index.markdown
+++ b/source/file-management-and-command-palette/index.markdown
@@ -26,7 +26,7 @@ Goto Anything 就像遊戲[傳送門](http://www.youtube.com/watch?v=QjF_AAiTPxk
 
 ## <span id="command-palette">指令面板（Command Palette）</span>
 
-指令面板是 Sublime Text 2 中使用內建指令、或是呼叫外掛的功能非常好用的東西，使用快捷鍵 <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> 開啟此面板。這個面板指令是讀取自所有的 `.sublime-commands` 檔案。
+指令面板是在 Sublime Text 2 中使用內建指令、呼叫外掛功能非常好用的東西。可從菜單 Tools > Command Palette… 中開啟（快捷鍵 <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>P</kbd>），指令面板中的列表讀取自所有後綴為 `.sublime-commands` 的檔案。
 
 以下例子是 _Packages/Default/Default.sublime-commands_ 檔案的一小部分：
 


### PR DESCRIPTION
1. 修改 README『發現錯誤要怎麼幫忙修改？』的第一條中『又上角』為『右上角』。
2. 對『檔案導覽與指令面板』中『指令面板（Command Palette）』一節中第一段進行潤色，使語句更連貫、通俗易懂。
3. 修改『基本概觀』中『Packages 目錄』一節，將『指令面板（Command Palette）』的鏈接由 /file-management-and-command-palette#command-palette 修改為 /file-management-and-command-palette/#command-palette，使其能正確跳轉到指定節。
4. 修改『基本概觀』中『User package』一節，對第二段文字進行潤色與精簡，使其連貫、不拖沓。
